### PR TITLE
Stop sending master credentials to slaves

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -27,13 +27,6 @@ class JenkinsMaster(RelationBase):
         log("Setting url relation to http://%s:8080" % address)
         relation_set(url="http://%s:8080" % address)
 
-        # Export credentials to the slave so it can download
-        # slave-agent.jnlp from the master.
-        log("Setting relation credentials")
-        credentials = Credentials()
-        relation_set(username=credentials.username())
-        relation_set(password=credentials.token())
-
         self.set_state("{relation_name}.connected")
 
     @hook("{requires:jenkins-slave}-relation-{changed}")


### PR DESCRIPTION
Sharing master credentials to slaves leads to security issues. A better way of allowing the slaves to download their agents is through a secret:
```
/var/lib/jenkins/agent.jar -jnlpUrl" ${JENKINS_URL}"/computer/"${JENKINS_SLAVEHOST}"/slave-agent.jnlp -secret ${JENKINS_SLAVEHOST_SECRET}"  -workDir "/var/lib/jenkins"
```
Also, I can't find this password being used anywhere by the jenkins-slave charm. So removing it now would cause no harm.

There's an open PR on the [jenkins-charm](https://github.com/jenkinsci/jenkins-charm/pull/81) to provide that secret through relations and I plan to work on the jenkins-slave charm next.